### PR TITLE
Update some resource to newer API groups.

### DIFF
--- a/k8s-mode.el
+++ b/k8s-mode.el
@@ -69,7 +69,7 @@
   :group 'k8s
   :type 'string)
 
-(defcustom k8s-site-docs-version "v1.13"
+(defcustom k8s-site-docs-version "v1.20"
   "Default version API."
   :group 'k8s
   :type 'string)

--- a/snippets/k8s-mode/horizontalpodautoscaler
+++ b/snippets/k8s-mode/horizontalpodautoscaler
@@ -3,7 +3,7 @@
 # key: hpas
 # expand-env: ((yas-indent-line 'fixed) (yas-wrap-around-region nil))
 # --
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {1:name}

--- a/snippets/k8s-mode/ingress
+++ b/snippets/k8s-mode/ingress
@@ -3,7 +3,7 @@
 # key: ingress
 # expand-env: ((yas-indent-line 'fixed) (yas-wrap-around-region nil))
 # --
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ${1}
@@ -17,5 +17,6 @@ spec:
     paths:
     - path: ${4:/}
       backend:
-        serviceName: ${5:service}
-        servicePort: ${6:80}
+        service:
+          name: ${5:service}
+          port: ${6:80}


### PR DESCRIPTION
Set the default k8s version to 1.20 - 1.13 no longer points to a valid
API documentation.

Ingress now as a non-extensions apiVersion and autoscaling a v1 version.