### PR TITLE
Adjust Ingress definition to add pathType and port.number

### DIFF
--- a/snippets/k8s-mode/ingress
+++ b/snippets/k8s-mode/ingress
@@ -14,9 +14,11 @@ spec:
   - secretName: ${3:secret}}
   rules:
   - http:
-    paths:
-    - path: ${4:/}
-      backend:
-        service:
-          name: ${5:service}
-          port: ${6:80}
+      paths:
+      - path: ${4:/}
+        pathType: ${5:Prefix}
+        backend:
+          service:
+            name: ${6:service}
+            port:
+              number: ${7:80}


### PR DESCRIPTION
I also adjusted the indentation to match the official example (https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource)