### PR TITLE
Add the host(s) as default field for ingress.

### DIFF
--- a/snippets/k8s-mode/ingress
+++ b/snippets/k8s-mode/ingress
@@ -12,14 +12,17 @@ metadata:
     #ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ${2:tls:
-  - secretName: ${3:secret}}
+  - hosts:
+    - $3
+    secretName: ${4:secret}}
   rules:
-  - http:
+  - host: ${3:fqdn}
+    http:
       paths:
-      - path: ${4:/}
-        pathType: ${5:Prefix}
+      - path: ${5:/}
+        pathType: ${6:Prefix}
         backend:
           service:
-            name: ${6:service}
+            name: ${7:service}
             port:
-              number: ${7:80}
+              number: ${8:80}


### PR DESCRIPTION
Not sure if this is useful for everyone, so please feel free to reject the PR if you think it's not.

But for me - I always end up having to add the host fields to the ingresses with the FQDN, so I get valid certificates from let's encrypt.