### PR TITLE
add support for Emacs `compile' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ From Emacs `M-x customize-group RET k8s RET`
 ;(setq k8s-search-documentation-browser-function (quote browse-url-firefox))
 
 ```
+```
 
+;; The kubeconfig file location
+(setq k8s-kubeconfig-location "~/.kube/config")
+
+```
 ##### Note
 
 Some of the snippets are inspired/copied from https://github.com/ismailyenigul/sublime-kubernetes-snippets . Thanks to the contributors of that project.

--- a/k8s-mode.el
+++ b/k8s-mode.el
@@ -45,6 +45,13 @@
   :type 'integer
   :group 'k8s)
 
+(defcustom k8s-kubeconfig-location
+  (or (getenv "KUBECONFIG")
+      "~/.kube/config")
+  "The location of your kubeconfig file."
+  :type 'string
+  :group 'k8s)
+
 (defvar k8s-keywords
   '("kind"))
 
@@ -120,7 +127,11 @@ See `k8s-search-documentation-browser-function'."
   (set (make-local-variable 'yaml-imenu-generic-expression) k8s-imenu-generic-expression)
   ;; completion
   (make-local-variable 'completion-at-point-functions)
-  (push 'k8s-complete-at-point completion-at-point-functions))
+  (push 'k8s-complete-at-point completion-at-point-functions)
+  ;; compilation
+  (setq-local compile-command (format "KUBECONFIG=%s kubectl apply -f %s"
+                                      k8s-kubeconfig-location
+                                      (shell-quote-argument buffer-file-name))))
 
 (eval-after-load 'yasnippet
   '(when (file-directory-p k8s-snip-dir) (yas-load-directory k8s-snip-dir)))


### PR DESCRIPTION
It would be nice to have the Emacs _compile_ command run `kubectl apply` on the file we are editing.
This PR adds this functionality.
Please let me know if there are any issues with it.